### PR TITLE
chore: wire analytics (GTM GTM-5VRWQ4ZF)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,20 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google Tag Manager -->
+    <script>
+      ;(function (w, d, s, l, i) {
+        w[l] = w[l] || []
+        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' })
+        var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s),
+          dl = l != 'dataLayer' ? '&l=' + l : ''
+        j.async = true
+        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl
+        f.parentNode.insertBefore(j, f)
+      })(window, document, 'script', 'dataLayer', 'GTM-5VRWQ4ZF')
+    </script>
+    <!-- End Google Tag Manager -->
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -1395,6 +1409,7 @@
     </style>
 </head>
 <body>
+    <!-- Google Tag Manager (noscript) --><noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5VRWQ4ZF" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript><!-- End Google Tag Manager (noscript) -->
     <!-- Skip to Main Content Link for Accessibility -->
     <a href="#main-content" class="skip-to-content">Skip to main content</a>
     

--- a/meet-schedule.html
+++ b/meet-schedule.html
@@ -1,6 +1,20 @@
 <!DOCTYPE html>
 <html lang="en-US">
 <head>
+    <!-- Google Tag Manager -->
+    <script>
+      ;(function (w, d, s, l, i) {
+        w[l] = w[l] || []
+        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' })
+        var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s),
+          dl = l != 'dataLayer' ? '&l=' + l : ''
+        j.async = true
+        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl
+        f.parentNode.insertBefore(j, f)
+      })(window, document, 'script', 'dataLayer', 'GTM-5VRWQ4ZF')
+    </script>
+    <!-- End Google Tag Manager -->
 	<meta charset="UTF-8" />
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="theme-color" content="#E8652D">
@@ -322,6 +336,7 @@
 </head>
 
 <body class="page-template-default page et_pb_pagebuilder_layout et_pb_show_title et_pb_button_helper_class et_fullwidth_nav et_fullwidth_secondary_nav et_fixed_nav et_show_nav et_cover_background et_pb_gutter windows et_pb_gutters3 et_primary_nav_dropdown_animation_fade et_secondary_nav_dropdown_animation_fade et_pb_footer_columns4 et_header_style_left et_pb_pagebuilder_layout et_right_sidebar et_divi_theme">
+    <!-- Google Tag Manager (noscript) --><noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5VRWQ4ZF" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript><!-- End Google Tag Manager (noscript) -->
 	<!-- Skip to Main Content Link for Accessibility -->
 	<a href="#main-content" class="skip-to-content">Skip to main content</a>
 	

--- a/privacy.html
+++ b/privacy.html
@@ -1,6 +1,20 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google Tag Manager -->
+    <script>
+      ;(function (w, d, s, l, i) {
+        w[l] = w[l] || []
+        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' })
+        var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s),
+          dl = l != 'dataLayer' ? '&l=' + l : ''
+        j.async = true
+        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl
+        f.parentNode.insertBefore(j, f)
+      })(window, document, 'script', 'dataLayer', 'GTM-5VRWQ4ZF')
+    </script>
+    <!-- End Google Tag Manager -->
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="theme-color" content="#E8652D">
@@ -92,6 +106,7 @@
     </style>
 </head>
 <body>
+    <!-- Google Tag Manager (noscript) --><noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5VRWQ4ZF" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript><!-- End Google Tag Manager (noscript) -->
     <!-- Skip to Main Content Link for Accessibility -->
     <a href="#main-content" class="skip-to-content">Skip to main content</a>
     

--- a/scripts/node_modules/htmlparser2/src/__fixtures__/Documents/Attributes.html
+++ b/scripts/node_modules/htmlparser2/src/__fixtures__/Documents/Attributes.html
@@ -1,9 +1,24 @@
 <!doctype html>
 <html>
 <head>
+    <!-- Google Tag Manager -->
+    <script>
+      ;(function (w, d, s, l, i) {
+        w[l] = w[l] || []
+        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' })
+        var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s),
+          dl = l != 'dataLayer' ? '&l=' + l : ''
+        j.async = true
+        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl
+        f.parentNode.insertBefore(j, f)
+      })(window, document, 'script', 'dataLayer', 'GTM-5VRWQ4ZF')
+    </script>
+    <!-- End Google Tag Manager -->
 	<title>Attributes test</title>
 </head>
 <body>
+    <!-- Google Tag Manager (noscript) --><noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5VRWQ4ZF" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript><!-- End Google Tag Manager (noscript) -->
 	<!-- Normal attributes -->
 	<button id="test0" class="value0" title="value1">class="value0" title="value1"</button>
 

--- a/scripts/node_modules/htmlparser2/src/__fixtures__/Documents/Basic.html
+++ b/scripts/node_modules/htmlparser2/src/__fixtures__/Documents/Basic.html
@@ -1,1 +1,2 @@
-<!DOCTYPE html><html><title>The Title</title><body>Hello world</body></html>
+<!DOCTYPE html><html><title>The Title</title><body>
+    <!-- Google Tag Manager (noscript) --><noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5VRWQ4ZF" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript><!-- End Google Tag Manager (noscript) -->Hello world</body></html>

--- a/scripts/node_modules/htmlparser2/src/__fixtures__/Documents/Svg.html
+++ b/scripts/node_modules/htmlparser2/src/__fixtures__/Documents/Svg.html
@@ -1,9 +1,24 @@
 <!doctype html>
 <html>
 <head>
+    <!-- Google Tag Manager -->
+    <script>
+      ;(function (w, d, s, l, i) {
+        w[l] = w[l] || []
+        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' })
+        var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s),
+          dl = l != 'dataLayer' ? '&l=' + l : ''
+        j.async = true
+        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl
+        f.parentNode.insertBefore(j, f)
+      })(window, document, 'script', 'dataLayer', 'GTM-5VRWQ4ZF')
+    </script>
+    <!-- End Google Tag Manager -->
 	<title>SVG test</title>
 </head>
 <body>
+    <!-- Google Tag Manager (noscript) --><noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5VRWQ4ZF" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript><!-- End Google Tag Manager (noscript) -->
 	<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 		<title>Test</title>
 		<animate />

--- a/season-2025-2026.html
+++ b/season-2025-2026.html
@@ -1,6 +1,20 @@
 <!DOCTYPE html>
 <html lang="en-US">
 <head>
+    <!-- Google Tag Manager -->
+    <script>
+      ;(function (w, d, s, l, i) {
+        w[l] = w[l] || []
+        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' })
+        var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s),
+          dl = l != 'dataLayer' ? '&l=' + l : ''
+        j.async = true
+        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl
+        f.parentNode.insertBefore(j, f)
+      })(window, document, 'script', 'dataLayer', 'GTM-5VRWQ4ZF')
+    </script>
+    <!-- End Google Tag Manager -->
 	<meta charset="UTF-8" />
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="theme-color" content="#E8652D">
@@ -454,6 +468,7 @@
 </head>
 
 <body class="page-template-default page et_pb_pagebuilder_layout et_pb_show_title et_pb_button_helper_class et_fullwidth_nav et_fullwidth_secondary_nav et_fixed_nav et_show_nav et_cover_background et_pb_gutter windows et_pb_gutters3 et_primary_nav_dropdown_animation_fade et_secondary_nav_dropdown_animation_fade et_pb_footer_columns4 et_header_style_left et_pb_pagebuilder_layout et_right_sidebar et_divi_theme">
+    <!-- Google Tag Manager (noscript) --><noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5VRWQ4ZF" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript><!-- End Google Tag Manager (noscript) -->
 	<!-- Skip to Main Content Link for Accessibility -->
 	<a href="#main-content" class="skip-to-content">Skip to main content</a>
 	

--- a/terms.html
+++ b/terms.html
@@ -1,6 +1,20 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google Tag Manager -->
+    <script>
+      ;(function (w, d, s, l, i) {
+        w[l] = w[l] || []
+        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' })
+        var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s),
+          dl = l != 'dataLayer' ? '&l=' + l : ''
+        j.async = true
+        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl
+        f.parentNode.insertBefore(j, f)
+      })(window, document, 'script', 'dataLayer', 'GTM-5VRWQ4ZF')
+    </script>
+    <!-- End Google Tag Manager -->
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="theme-color" content="#E8652D">
@@ -92,6 +106,7 @@
     </style>
 </head>
 <body>
+    <!-- Google Tag Manager (noscript) --><noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5VRWQ4ZF" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript><!-- End Google Tag Manager (noscript) -->
     <!-- Skip to Main Content Link for Accessibility -->
     <a href="#main-content" class="skip-to-content">Skip to main content</a>
     


### PR DESCRIPTION
Wires analytics ids into this site (public client-side ids, not secrets).

- GTM container: `GTM-5VRWQ4ZF` (FFC-owned, via workflow 503)
- GA4 measurement id: `G-MCWLFVZ0LT` (via workflow 505; GA4 fires inside the GTM container)

Generated by FFC workflow **704. Website - Analytics Wire**. Part of the fleet analytics
rollout (FreeForCharity/FFC-Cloudflare-Automation#629).