### PR TITLE
fix(footer): add Supported Charity Login hub link

### DIFF
--- a/index.html
+++ b/index.html
@@ -1409,7 +1409,7 @@
     </style>
 </head>
 <body>
-    <!-- Google Tag Manager (noscript) --><noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5VRWQ4ZF" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript><!-- End Google Tag Manager (noscript) -->
+    <!-- Google Tag Manager (noscript) --><noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5VRWQ4ZF" title="Google Tag Manager" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript><!-- End Google Tag Manager (noscript) -->
     <!-- Skip to Main Content Link for Accessibility -->
     <a href="#main-content" class="skip-to-content">Skip to main content</a>
     
@@ -1878,6 +1878,7 @@
                             <li><a href="#fundraising">Donate</a></li>
                             <li><a href="#fundraising">Volunteer</a></li>
                             <li><a href="https://github.com/FreeForCharity/FFC-EX-PAGboosters.org" target="_blank" rel="noopener noreferrer">GitHub Repository</a></li>
+                            <li><a href="https://freeforcharity.org/hub/" target="_blank" rel="noopener noreferrer">Supported Charity Login</a></li>
                             <li><a href="privacy.html">Privacy Policy</a></li>
                             <li><a href="terms.html">Terms of Use</a></li>
                         </ul>

--- a/meet-schedule.html
+++ b/meet-schedule.html
@@ -336,7 +336,7 @@
 </head>
 
 <body class="page-template-default page et_pb_pagebuilder_layout et_pb_show_title et_pb_button_helper_class et_fullwidth_nav et_fullwidth_secondary_nav et_fixed_nav et_show_nav et_cover_background et_pb_gutter windows et_pb_gutters3 et_primary_nav_dropdown_animation_fade et_secondary_nav_dropdown_animation_fade et_pb_footer_columns4 et_header_style_left et_pb_pagebuilder_layout et_right_sidebar et_divi_theme">
-    <!-- Google Tag Manager (noscript) --><noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5VRWQ4ZF" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript><!-- End Google Tag Manager (noscript) -->
+    <!-- Google Tag Manager (noscript) --><noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5VRWQ4ZF" title="Google Tag Manager" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript><!-- End Google Tag Manager (noscript) -->
 	<!-- Skip to Main Content Link for Accessibility -->
 	<a href="#main-content" class="skip-to-content">Skip to main content</a>
 	
@@ -720,6 +720,7 @@
 								<li><a href="index.html#fundraising">Donate</a></li>
 								<li><a href="index.html#fundraising">Volunteer</a></li>
 								<li><a href="https://github.com/FreeForCharity/FFC-EX-PAGboosters.org" target="_blank" rel="noopener noreferrer">GitHub Repository</a></li>
+								<li><a href="https://freeforcharity.org/hub/" target="_blank" rel="noopener noreferrer">Supported Charity Login</a></li>
 								<li><a href="privacy.html">Privacy Policy</a></li>
 								<li><a href="terms.html">Terms of Use</a></li>
 							</ul>

--- a/privacy.html
+++ b/privacy.html
@@ -106,7 +106,7 @@
     </style>
 </head>
 <body>
-    <!-- Google Tag Manager (noscript) --><noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5VRWQ4ZF" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript><!-- End Google Tag Manager (noscript) -->
+    <!-- Google Tag Manager (noscript) --><noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5VRWQ4ZF" title="Google Tag Manager" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript><!-- End Google Tag Manager (noscript) -->
     <!-- Skip to Main Content Link for Accessibility -->
     <a href="#main-content" class="skip-to-content">Skip to main content</a>
     
@@ -241,6 +241,7 @@
                         <li><a href="index.html#fundraising">Donate</a></li>
                         <li><a href="index.html#fundraising">Volunteer</a></li>
                         <li><a href="https://github.com/FreeForCharity/FFC-EX-PAGboosters.org" target="_blank" rel="noopener noreferrer">GitHub Repository</a></li>
+                        <li><a href="https://freeforcharity.org/hub/" target="_blank" rel="noopener noreferrer">Supported Charity Login</a></li>
                         <li><a href="privacy.html">Privacy Policy</a></li>
                         <li><a href="terms.html">Terms of Use</a></li>
                     </ul>

--- a/season-2025-2026.html
+++ b/season-2025-2026.html
@@ -468,7 +468,7 @@
 </head>
 
 <body class="page-template-default page et_pb_pagebuilder_layout et_pb_show_title et_pb_button_helper_class et_fullwidth_nav et_fullwidth_secondary_nav et_fixed_nav et_show_nav et_cover_background et_pb_gutter windows et_pb_gutters3 et_primary_nav_dropdown_animation_fade et_secondary_nav_dropdown_animation_fade et_pb_footer_columns4 et_header_style_left et_pb_pagebuilder_layout et_right_sidebar et_divi_theme">
-    <!-- Google Tag Manager (noscript) --><noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5VRWQ4ZF" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript><!-- End Google Tag Manager (noscript) -->
+    <!-- Google Tag Manager (noscript) --><noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5VRWQ4ZF" title="Google Tag Manager" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript><!-- End Google Tag Manager (noscript) -->
 	<!-- Skip to Main Content Link for Accessibility -->
 	<a href="#main-content" class="skip-to-content">Skip to main content</a>
 	
@@ -1478,6 +1478,7 @@
 								<li><a href="index.html#fundraising">Donate</a></li>
 								<li><a href="index.html#fundraising">Volunteer</a></li>
 								<li><a href="https://github.com/FreeForCharity/FFC-EX-PAGboosters.org" target="_blank" rel="noopener noreferrer">GitHub Repository</a></li>
+								<li><a href="https://freeforcharity.org/hub/" target="_blank" rel="noopener noreferrer">Supported Charity Login</a></li>
 								<li><a href="privacy.html">Privacy Policy</a></li>
 								<li><a href="terms.html">Terms of Use</a></li>
 							</ul>

--- a/terms.html
+++ b/terms.html
@@ -106,7 +106,7 @@
     </style>
 </head>
 <body>
-    <!-- Google Tag Manager (noscript) --><noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5VRWQ4ZF" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript><!-- End Google Tag Manager (noscript) -->
+    <!-- Google Tag Manager (noscript) --><noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5VRWQ4ZF" title="Google Tag Manager" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript><!-- End Google Tag Manager (noscript) -->
     <!-- Skip to Main Content Link for Accessibility -->
     <a href="#main-content" class="skip-to-content">Skip to main content</a>
     
@@ -255,6 +255,7 @@
                         <li><a href="index.html#fundraising">Donate</a></li>
                         <li><a href="index.html#fundraising">Volunteer</a></li>
                         <li><a href="https://github.com/FreeForCharity/FFC-EX-PAGboosters.org" target="_blank" rel="noopener noreferrer">GitHub Repository</a></li>
+                        <li><a href="https://freeforcharity.org/hub/" target="_blank" rel="noopener noreferrer">Supported Charity Login</a></li>
                         <li><a href="privacy.html">Privacy Policy</a></li>
                         <li><a href="terms.html">Terms of Use</a></li>
                     </ul>


### PR DESCRIPTION
Refs FreeForCharity/FFC-Cloudflare-Automation#697 (fleet footer retrofit — attribution quick wins)

## What this closes (fleet audit checks for pagbooster.org)

- **hub link** — adds the FFC-standard `Supported Charity Login` link (https://freeforcharity.org/hub/) to the footer Resources column on all five pages (index, meet-schedule, season-2025-2026, privacy, terms). This was the only failing check; footer marker, FFC link, "Supported by" target wording, and EIN were already present.

## Also included (CI unblock)

- Adds `title="Google Tag Manager"` to the GTM noscript iframe introduced in #72 — that iframe broke the Accessibility Guard lint on `main` (`@html-eslint/require-frame-title`), so this PR could not go green without it.

## Test plan

- `npm run lint` (Accessibility Guard's exact CI step) passes locally with both changes; it fails on current `main`.
- Hub link matches existing Resources-column link markup/styling (`target="_blank" rel="noopener noreferrer"`, existing `.footer-column` styles).

No charity data (EIN/GuideStar/status) was touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)