### PR TITLE
fix: public/CNAME matches the Pages custom domain

### DIFF
--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+pagbooster.org


### PR DESCRIPTION
FreeForCharity/FFC-Cloudflare-Automation#740: sets public/CNAME=pagbooster.org to match the Pages binding.